### PR TITLE
Add link to full article

### DIFF
--- a/assets/css/components/_layout.scss
+++ b/assets/css/components/_layout.scss
@@ -134,6 +134,13 @@ a {
     margin: 0;
 }
 
+.more {
+    text-align: right;
+    &:before {
+        content: '> ';
+    }
+}
+
 
 // 3. Grid
 // ---------

--- a/index-en.html
+++ b/index-en.html
@@ -68,7 +68,10 @@ ref: home
       </h3>
       <p class="subtitle">{% include date.html date=post.date %}{{ month }} {{ year }}</p>
       {% if post.excerpt %}
-      {{ post.excerpt }}
+        {{ post.excerpt }}
+        <p class="more">
+          <a href="{{ post.url }}">En lire plus</a>
+        </p>
       {% endif %}
       {% if post.image %}
       <img src="{{ site.baseurl }}/{{ post.image }}" style="width: 100%; height: auto">

--- a/index-es.html
+++ b/index-es.html
@@ -73,7 +73,10 @@ ref: home
       </h3>
       <p class="subtitle">{% include date.html date=post.date %}{{ month }} {{ year }}</p>
       {% if post.excerpt %}
-      {{ post.excerpt }}
+        {{ post.excerpt }}
+        <p class="more">
+          <a href="{{ post.url }}">En lire plus</a>
+        </p>
       {% endif %}
       {% if post.image %}
       <img src="{{ site.baseurl }}/{{ post.image }}" style="width: 100%; height: auto">

--- a/index.html
+++ b/index.html
@@ -70,7 +70,10 @@ ref: home
       </h3>
       <p class="subtitle">{% include date.html date=post.date %}{{ month }} {{ year }}</p>
       {% if post.excerpt %}
-      {{ post.excerpt }}
+        {{ post.excerpt }}
+        <p class="more">
+          <a href="{{ post.url }}">En lire plus</a>
+        </p>
       {% endif %}
       {% if post.image %}
       <img src="{{ site.baseurl }}/{{ post.image }}" style="width: 100%; height: auto">


### PR DESCRIPTION
Using [post excerpt](https://jekyllrb.com/docs/posts/#post-excerpts) functionnality, I added an link on actu in index page. But this link appears even if full content equals the article.